### PR TITLE
[TimeZoneUpdater.py] Apply fixes and updates

### DIFF
--- a/CI/futurize.sh
+++ b/CI/futurize.sh
@@ -8,13 +8,13 @@ echo ""
 echo "Changing py files, please wait ..." 
 begin=$(date +"%s")
 
-echo ""
-echo "Convert python 2 print to python 3 print"
-find . -name "*.py" -type f -exec futurize -w -f libfuturize.fixes.fix_print_with_import {} \;
-find . -name "*.bak" -type f -exec rm -rf {} \;
-git add -u
-git add *
-git commit -m "Use futurize to have python 3 compatible print"
+#echo ""
+#echo "Convert python 2 print to python 3 print"
+#find . -name "*.py" -type f -exec futurize -w -f libfuturize.fixes.fix_print_with_import {} \;
+#find . -name "*.bak" -type f -exec rm -rf {} \;
+#git add -u
+#git add *
+#git commit -m "Use futurize to have python 3 compatible print"
 
 echo ""
 echo "Convert python 2 long to python 3 int"


### PR DESCRIPTION
- Correct path to Python executable.
- Remove unnecessary import.
- Add "TIMEZONEBASE" to allow control of the zone name.  The default is "GMT" but can be "UTC" or other string as appropriate.
- Add a blank line between the comment and the data.
- Bump version number.
- Make the "dst" variable Boolean and adjust the XML decoder to solve the returned value not being as specified in the API manual.
  (The API guide indicates the value returned is "1"/"0" but is currently "true"/"false".  I also allow for "yes"/"no" as this is also mentioned.)
- Restore more accurate date of when the data was built.
